### PR TITLE
Add Duniverse.Config.Clone pull mode.

### DIFF
--- a/cli/init.ml
+++ b/cli/init.ml
@@ -97,14 +97,19 @@ open Cmdliner
 let pull_mode =
   let doc =
     "How to pull the sources. If $(i,submodules), the pull command will initialise them as git \
-     submodules.  If $(i,source) then the source code will directly be cloned to the source tree."
+     submodules.  If $(i,source) then the source code will directly be copied to the source tree.
+     If $(i,clone) then sources are cloned as git repositories (but not added as submodules)."
   in
   Common.Arg.named
     (fun x -> `Pull_mode x)
     Arg.(
       value
       & opt
-          (enum [ ("submodule", Duniverse.Config.Submodules); ("source", Duniverse.Config.Source) ])
+          (enum [
+            ("submodule", Duniverse.Config.Submodules);
+            ("clone", Duniverse.Config.Clone);
+            ("source", Duniverse.Config.Source)
+          ])
           Duniverse.Config.Source
       & info [ "pull-mode" ] ~docv:"PULL_MODE" ~doc)
 

--- a/lib/duniverse.ml
+++ b/lib/duniverse.ml
@@ -214,7 +214,7 @@ module Tools = struct
 end
 
 module Config = struct
-  type pull_mode = Submodules | Source [@@deriving sexp]
+  type pull_mode = Submodules | Clone | Source [@@deriving sexp]
 
   type t = {
     version: string;

--- a/lib/duniverse.mli
+++ b/lib/duniverse.mli
@@ -109,7 +109,7 @@ module Tools : sig
 end
 
 module Config : sig
-  type pull_mode = Submodules | Source [@@deriving sexp]
+  type pull_mode = Submodules | Clone | Source [@@deriving sexp]
 
   type t = {
     version: string;

--- a/lib/pull.ml
+++ b/lib/pull.ml
@@ -97,9 +97,10 @@ let duniverse ~cache ~pull_mode ~repo duniverse =
   let duniverse_dir = Fpath.(repo // Config.vendor_dir) in
   Bos.OS.Dir.create duniverse_dir >>= fun _created ->
   mark_duniverse_content_as_vendored ~duniverse_dir >>= fun () ->
-  let sm = pull_mode = Duniverse.Config.Submodules in
-  pull_source_dependencies ~trim_clone:(not sm) ~duniverse_dir ~cache duniverse >>= fun () ->
-  if sm then set_git_submodules ~repo ~duniverse_dir duniverse else Ok ()
+  let trim_clone = pull_mode = Duniverse.Config.Source in
+  pull_source_dependencies ~trim_clone ~duniverse_dir ~cache duniverse >>= fun () ->
+  if pull_mode = Duniverse.Config.Submodules then
+    set_git_submodules ~repo ~duniverse_dir duniverse else Ok ()
 
 
 


### PR DESCRIPTION
This allows keeping the sources as git repositories without adding them
as submodules. This is useful in when ./duniverse is git-ignored,
allowing for a convenient way to work on cloned dependencies.